### PR TITLE
Re-uses the guid of the original form

### DIFF
--- a/Umbraco.Forms.Migration/MigrationService.cs
+++ b/Umbraco.Forms.Migration/MigrationService.cs
@@ -27,6 +27,7 @@ namespace Umbraco.Forms.Migration
                 {
                     var v4Form = new Umbraco.Forms.Core.Form();
 
+                    v4Form.Id = form.Id;
                     v4Form.Name = form.Name;
                     v4Form.DisableDefaultStylesheet = form.DisableDefaultStylesheet;
                     v4Form.FieldIndicationType = (FormFieldIndication)System.Enum.Parse(typeof(FormFieldIndication), ((int)form.FieldIndicationType).ToString()); ;


### PR DESCRIPTION
This re-uses the guid of the original form instead of letting the new forms module generate one.

This appears to resolve an issue we had where the migration wizard would generate a duplicate copy of one of the forms, with a guid of 00000000-0000-0000-0000-000000000000.

It will also make it easier to automate the replacement of the macros in content fields, if we decide to do that at a later date.
