### PR TITLE
Extended plugin to also import records (form entries)

### DIFF
--- a/Umbraco.Forms.Migration/Contour/Data/RecordStorage/RecordFieldStorage.cs
+++ b/Umbraco.Forms.Migration/Contour/Data/RecordStorage/RecordFieldStorage.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using umbraco.DataLayer;
+
+namespace Umbraco.Forms.Migration.Data.Storage
+{
+    public class RecordFieldStorage : IDisposable
+    {
+        private RecordFieldValueStorage recordFieldValueStorage;
+        private object formCacheSyncLock = new object();
+
+        private ISqlHelper sqlHelper;
+
+        public RecordFieldStorage(ISqlHelper connection)
+        {
+            init(connection);
+        }
+
+        private void init(ISqlHelper connection)
+        {
+            sqlHelper = connection;
+            recordFieldValueStorage = new RecordFieldValueStorage(connection);
+        }
+
+
+        public Dictionary<Guid, RecordField> GetAllRecordFields(Record record, Form form)
+        {
+            string sql = "SELECT * FROM UFRecordFields where Record = @record";
+            Dictionary<Guid, RecordField> l = new Dictionary<Guid, RecordField>();
+
+            IRecordsReader rr = sqlHelper.ExecuteReader(sql, sqlHelper.CreateParameter("@record", record.Id));
+
+            while (rr.Read())
+            {
+                RecordField r = RecordField.CreateFromDataReader(rr);
+                r.Values = recordFieldValueStorage.GetRecordFieldValues(r);
+                l.Add(r.FieldId, r);
+            }
+
+            rr.Dispose();
+
+            return l;
+
+        }
+
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            sqlHelper.Dispose();
+            recordFieldValueStorage.Dispose();
+
+            sqlHelper = null;
+            formCacheSyncLock = null;
+        }
+
+        #endregion
+    }
+}

--- a/Umbraco.Forms.Migration/Contour/Data/RecordStorage/RecordFieldValueStorage.cs
+++ b/Umbraco.Forms.Migration/Contour/Data/RecordStorage/RecordFieldValueStorage.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using umbraco.DataLayer;
+
+namespace Umbraco.Forms.Migration.Data.Storage
+{
+    public class RecordFieldValueStorage :IDisposable
+    {
+        private object formCacheSyncLock = new object();
+
+        private ISqlHelper sqlHelper;
+
+        public RecordFieldValueStorage(ISqlHelper connection)
+        {
+            init(connection);
+        }
+
+        private void init(ISqlHelper connection)
+        {
+            sqlHelper = connection;
+        }
+
+        public List<object> GetRecordFieldValues(RecordField rf)
+        {
+            string sql = string.Format("SELECT * FROM UFRecordData{0} where [Key] = @key ORDER BY Id ASC", rf.DataTypeAlias);
+            List<object> l = new List<object>();
+
+            IRecordsReader rr = sqlHelper.ExecuteReader(sql, sqlHelper.CreateParameter("@key", rf.Key));
+
+            while (rr.Read())
+            {
+                switch(rf.DataType)
+                {
+                    case FieldDataType.String:
+                    case FieldDataType.LongString:
+                        l.Add(rr.GetString("Value"));
+                        break;
+                    case FieldDataType.Integer:
+                        l.Add(rr.GetInt("Value"));
+                        break;
+                    case FieldDataType.DateTime:
+                        l.Add(rr.GetDateTime("Value"));
+                        break;
+                    case FieldDataType.Bit:
+                        l.Add(rr.GetBoolean("Value"));
+                        break;
+                }
+            }
+
+            rr.Dispose();
+
+            return l;
+        }
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            sqlHelper.Dispose();
+
+            sqlHelper = null;
+            formCacheSyncLock = null;
+        }
+
+        #endregion
+    }
+}

--- a/Umbraco.Forms.Migration/Contour/Data/RecordStorage/RecordStorage.cs
+++ b/Umbraco.Forms.Migration/Contour/Data/RecordStorage/RecordStorage.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using umbraco.DataLayer;
+
+namespace Umbraco.Forms.Migration.Data.Storage
+{
+    public class RecordStorage : IDisposable
+    {
+        private RecordFieldStorage recordFieldStorage;
+        private object formCacheSyncLock = new object();
+
+        private ISqlHelper sqlHelper;
+        
+        public RecordStorage(ISqlHelper connection)
+        {
+            init(connection);
+        }
+
+        private void init(ISqlHelper connection)
+        {
+            sqlHelper = connection;
+            recordFieldStorage = new RecordFieldStorage(connection);
+        }
+
+        public List<Record> GetAllRecords(Form form)
+        {
+            string sql = "SELECT * FROM UFRecords where form = @form ORDER BY created ASC";
+            List<Record> l = new List<Record>();
+
+            IRecordsReader rr = sqlHelper.ExecuteReader(sql, sqlHelper.CreateParameter("@form", form.Id));
+
+            while (rr.Read())
+            {
+                Record r = Record.CreateFromDataReader(rr);
+                r.RecordFields = recordFieldStorage.GetAllRecordFields(r, form);
+                l.Add(r);
+            }
+
+            rr.Dispose();
+
+            return l;
+        }
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            sqlHelper.Dispose();
+            recordFieldStorage.Dispose();
+
+            sqlHelper = null;
+            formCacheSyncLock = null;
+        }
+
+        #endregion
+    }
+}

--- a/Umbraco.Forms.Migration/Contour/Record.cs
+++ b/Umbraco.Forms.Migration/Contour/Record.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using umbraco.DataLayer;
+
+namespace Umbraco.Forms.Migration
+{
+    public class Record
+    {
+        public static Record Create()
+        {
+            Record record = new Record();
+
+            return record;
+        }
+
+        public Record()
+        {
+        }
+
+        public static Record CreateFromDataReader(IRecordsReader reader)
+        {
+            Record record = Create();
+            record.Id            = reader.GetGuid("Id");
+            record.Form          = reader.GetGuid("Form");
+            record.Created       = reader.GetDateTime("Created");
+            record.Updated       = reader.GetDateTime("Updated");
+            record.State         = reader.GetInt("State");
+            record.currentPage   = reader.GetGuid("currentPage");
+            record.umbracoPageId = reader.GetInt("umbracoPageId");
+            record.IP            = reader.GetString("IP");
+            record.MemberKey     = reader.GetString("MemberKey");
+            return record;
+        }
+
+        public Guid Id { get; set; }
+        public Guid Form { get; set; }
+        public DateTime Created { get; set; }
+        public DateTime Updated { get; set; }
+        public int State { get; set; }
+        public Guid currentPage { get; set; }
+        public int umbracoPageId { get; set; }
+        public string IP { get; set; }
+        public string MemberKey { get; set; }
+        public Dictionary<Guid, RecordField> RecordFields { get; set; }
+    }
+}

--- a/Umbraco.Forms.Migration/Contour/RecordField.cs
+++ b/Umbraco.Forms.Migration/Contour/RecordField.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using umbraco.DataLayer;
+
+namespace Umbraco.Forms.Migration
+{
+    public class RecordField
+    {
+        public RecordField()
+        {
+
+        }
+
+        public FieldDataType DataType { get; set; }
+        public string DataTypeAlias { get; set; }
+        public Field Field { get; set; }
+        public Guid FieldId { get; set; }
+        public Guid Key { get; set; }
+        public Guid Record { get; set; }
+        public List<object> Values { get; set; }
+
+        public static RecordField CreateFromDataReader(IRecordsReader reader)
+        {
+            RecordField recordField   = new RecordField();
+            recordField.Key           = reader.GetGuid("Key");
+            recordField.FieldId       = reader.GetGuid("Field");
+            recordField.Record        = reader.GetGuid("Record");
+            recordField.DataTypeAlias = reader.GetString("DataType");
+            recordField.DataType      = (FieldDataType)Enum.Parse(typeof(FieldDataType), recordField.DataTypeAlias);
+            recordField.Values        = new List<object>();
+            return recordField;
+        }
+    }
+}

--- a/Umbraco.Forms.Migration/MigrationService.cs
+++ b/Umbraco.Forms.Migration/MigrationService.cs
@@ -122,6 +122,11 @@ namespace Umbraco.Forms.Migration
                         v4Form.Pages.Add(v4Page);
                     }
 
+                    using (var s = new Forms.Data.Storage.FormStorage())
+                    {
+                        v4Form = s.InsertForm(v4Form);
+                    }
+
                     using (var ws = new WorkflowStorage(sql))
                     {
                         var wfs = ws.GetAllWorkFlows(form);
@@ -141,14 +146,7 @@ namespace Umbraco.Forms.Migration
                             }
                         }
                     }
-
-
-                    using (var s = new Forms.Data.Storage.FormStorage()) { 
-                        v4Form = s.InsertForm(v4Form);
-                    }
-
-
-
+                    
                     // store records
                     using (var rs = new RecordStorage(sql))
                     {

--- a/Umbraco.Forms.Migration/MigrationService.cs
+++ b/Umbraco.Forms.Migration/MigrationService.cs
@@ -127,12 +127,12 @@ namespace Umbraco.Forms.Migration
                         {
                             using (var wsv4 = new Forms.Data.Storage.WorkflowStorage())
                             {
-                                
                                 var v4Workflow = new Core.Workflow();
                                 v4Workflow.Name = workflow.Name;
                                 v4Workflow.Id = workflow.Id;
                                 v4Workflow.Type = workflow.Type;
-                                v4Workflow.ExecutesOn = (Core.Enums.FormState)System.Enum.Parse(typeof(Core.Enums.FormState), ((int)workflow.ExecutesOn).ToString()); ; ;
+                                v4Workflow.ExecutesOn = (Core.Enums.FormState)System.Enum.Parse(typeof(Core.Enums.FormState), ((int)workflow.ExecutesOn).ToString());
+                                v4Workflow.Form = v4Form.Id;
                                 v4Workflow.Settings = workflow.Settings;
                                 wsv4.InsertWorkflow(v4Form,v4Workflow);
                             }

--- a/Umbraco.Forms.Migration/Umbraco.Forms.Migration.csproj
+++ b/Umbraco.Forms.Migration/Umbraco.Forms.Migration.csproj
@@ -230,6 +230,9 @@
     <Compile Include="Contour\Data\FormStorage\PageStorage.cs" />
     <Compile Include="Contour\Data\FormStorage\PreValueStorage.cs" />
     <Compile Include="Contour\Data\PrevalueSourceStorage\PrevalueSourceStorage.cs" />
+    <Compile Include="Contour\Data\RecordStorage\RecordFieldStorage.cs" />
+    <Compile Include="Contour\Data\RecordStorage\RecordFieldValueStorage.cs" />
+    <Compile Include="Contour\Data\RecordStorage\RecordStorage.cs" />
     <Compile Include="Contour\Data\SettingsStorage\SettingsStorage.cs" />
     <Compile Include="Contour\Data\SqlHelper.cs" />
     <Compile Include="Contour\Data\WorkflowStorage\WorkflowStorage.cs" />
@@ -261,6 +264,8 @@
     </Compile>
     <Compile Include="MigrationService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Contour\Record.cs" />
+    <Compile Include="Contour\RecordField.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\FilterConfig.cs" />


### PR DESCRIPTION
First commit just sets the form GUID on the workflows. The workflows were imported correctly, showed up and were working, but could not be deleted due to the GUID being all 0s in the workflow json files in App_Plugins\UmbracoForms\Data\workflows
On a side note, this bug could be related: http://issues.umbraco.org/issue/CON-773

I have then extended the plugin to also import entries.
On our database the UFRecordFields records all had the DataType set to 'String', even when they were of another DataType. I have included a script that fixes the DataTypes in the UFRecordFields table - please note that this changes data in the database the data is imported from.
